### PR TITLE
Exercise Part 3 Started

### DIFF
--- a/TASK_3_IDEAS.md
+++ b/TASK_3_IDEAS.md
@@ -1,0 +1,67 @@
+# Task 3 Stretch Planning/ Insight
+
+Here is a insight of ideas/ planning of how to apply the stretch task.
+
+---
+
+## Table of Contents
+
+- [Implementing The Solution](#how-you-would-go-about-implementing-the-solution)
+- [Problems](#what-problems-you-might-encounter)
+- [Testing](#how-you-would-go-about-testing)
+- [Next Time](#what-you-might-do-differently)
+- [Added On](#currently-added)
+
+---
+
+## How you would go about implementing the solution
+
+Currently we can see there is a implementation of tags in the conversation model object for the REST interface.
+The schema for conversation looks to have tag field and if you use the below method to which creates a conversation you are able to include a tag.
+
+```
+POST /conversation
+```
+
+It seems possible to update the tag with the below method based on the conversation id.
+
+```
+PUT /conversation/{conversationId}/tags
+```
+
+Seems the approach to take would be to reuse the way tags are implemented in conversation for the REST interface but to a single chat message for the GraphQL interface. This would require:
+
+- Adding into the message schema for graphQL the tags fields in a single chat message.
+- Update the conversation schema for graphQL to provide the tag fields.
+- Create a mutation for the ability to add a single chat message.
+- Create a query that gathers chat messages in a conversation using matches anything that has that string.
+- Create tests to validate the task and add ons.
+
+---
+
+## What problems you might encounter
+
+Some of the possibilities that can be encountered when implementing this task can be, any user is being allowed to define their own tags if not monitored could lead to injection attacks in addition database performances could be impacted when dealing with large varies of tags or queries needed to obtain the tags.
+
+---
+
+## How you would go about testing
+
+When testing we can take the approach of TDD (test driven development) this would mean creating the test's first to define the boundaries on expectations and then writing the source code. In addition we can overlook the current tests in place and see if
+they need to updated or adapted to accommodate the changes.
+
+Tests would include:
+
+- Unit/Integration tests
+- API tests
+
+---
+
+## Currently added
+
+While I have not applied to much to the source code. I have made a slight start to the process to which you will see that I have added onto the graphQL schema for messages.
+
+The files that have been updated are:
+
+- `message.model.ts`
+- `message.entity.ts`

--- a/src/message/models/message.entity.ts
+++ b/src/message/models/message.entity.ts
@@ -148,6 +148,9 @@ export class ChatMessage {
 
   @Field({ defaultValue: false, nullable: true })
   isSenderBlocked?: boolean;
+
+  @Field(() => [String], { defaultValue: [] })
+  tags?: Array<string>;
 }
 
 /***

--- a/src/message/models/message.model.ts
+++ b/src/message/models/message.model.ts
@@ -154,6 +154,12 @@ export class ChatMessageModel {
   })
   reactions?: Reaction[];
 
+  @Prop({
+    required: false,
+    default: [],
+  })
+  tags?: Array<string>;
+
   /**
    * All the properties below are virtual properties
    * @url https://mongoosejs.com/docs/tutorials/virtuals.html


### PR DESCRIPTION
Problem Started:

Currently, we allow tags to be added to a conversation, so we can help users to find things they're interested in.

We would like to extend the functionality, to allow the sender of a message to add or update tags on a single message, and allow other users to find messages based on these tags.

While we don't expect everyone to complete this part of the exercise, it will form the basis of discussion in an interview. Please make as much progress with this, as you feel comfortable doing. Don't allow it to be all-consuming. A couple of hours at most for all parts of the exercise.